### PR TITLE
NEXT-5623 | Support present modally with iPad

### DIFF
--- a/Pod/Classes/MenuItemView.swift
+++ b/Pod/Classes/MenuItemView.swift
@@ -62,6 +62,7 @@ open class MenuItemView: UIView {
     fileprivate var menuItemOptions: MenuItemViewCustomizable!
     fileprivate var widthConstraint: NSLayoutConstraint!
     fileprivate var descriptionWidthConstraint: NSLayoutConstraint!
+    fileprivate var viewWidth: CGFloat = 0.0
     fileprivate var horizontalMargin: CGFloat {
         switch menuOptions.displayMode {
         case .segmentedControl: return 0.0
@@ -71,12 +72,13 @@ open class MenuItemView: UIView {
     
     // MARK: - Lifecycle
     
-    internal init(menuOptions: MenuViewCustomizable, menuItemOptions: MenuItemViewCustomizable, addDiveder: Bool) {
+    internal init(menuOptions: MenuViewCustomizable, menuItemOptions: MenuItemViewCustomizable, addDiveder: Bool, viewWidth: CGFloat) {
         super.init(frame: .zero)
         
         self.menuOptions = menuOptions
         self.menuItemOptions = menuItemOptions
-        
+        self.viewWidth = viewWidth
+
         switch menuItemOptions.displayMode {
         case .text(let title):
             commonInit({
@@ -324,6 +326,9 @@ extension MenuItemView {
     }
     
     fileprivate var maxWindowSize: CGFloat {
+        if viewWidth > 0.0 {
+            return viewWidth
+        }
         return UIApplication.shared.keyWindow?.bounds.width ?? UIScreen.main.bounds.width
     }
 }

--- a/Pod/Classes/MenuView.swift
+++ b/Pod/Classes/MenuView.swift
@@ -78,12 +78,12 @@ open class MenuView: UIScrollView {
     fileprivate var currentIndex: Int = 0
     
     // MARK: - Lifecycle
-    internal init(menuOptions: MenuViewCustomizable) {
+    internal init(menuOptions: MenuViewCustomizable, viewWidth: CGFloat) {
         super.init(frame: CGRect(x: 0, y: 0, width: 0, height: menuOptions.height))
         
         self.menuOptions = menuOptions
         
-        commonInit({ self.constructMenuItemViews(menuOptions) })
+        commonInit({ self.constructMenuItemViews(menuOptions, viewWidth: viewWidth) })
     }
     
     fileprivate func commonInit(_ constructor: () -> Void) {
@@ -218,9 +218,9 @@ open class MenuView: UIScrollView {
         contentView.layer.addSublayer(border)
     }
     
-    fileprivate func constructMenuItemViews(_ menuOptions: MenuViewCustomizable) {
+    fileprivate func constructMenuItemViews(_ menuOptions: MenuViewCustomizable, viewWidth: CGFloat) {
         constructMenuItemViews({
-            return MenuItemView(menuOptions: menuOptions, menuItemOptions: menuOptions.itemsOptions[$0], addDiveder: $1)
+            return MenuItemView(menuOptions: menuOptions, menuItemOptions: menuOptions.itemsOptions[$0], addDiveder: $1, viewWidth: viewWidth)
         })
     }
     

--- a/Pod/Classes/PagingMenuController.swift
+++ b/Pod/Classes/PagingMenuController.swift
@@ -96,11 +96,11 @@ open class PagingMenuController: UIViewController {
         }
     }
 
-    // MARK: - Public
-    
-    open func setup(_ options: PagingMenuControllerCustomizable) {
-        self.options = options
-        
+    open override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        guard UIDevice.current.userInterfaceIdiom == .pad, isPresentedModally else { return }
+
         switch options.componentType {
         case .all(let menuOptions, _):
             self.menuOptions = menuOptions
@@ -108,10 +108,31 @@ open class PagingMenuController: UIViewController {
             self.menuOptions = menuOptions
         default: break
         }
-        
+
         setupMenuView()
         setupMenuController()
-        
+
+        move(toPage: currentPage, animated: false)
+    }
+
+    // MARK: - Public
+    
+    open func setup(_ options: PagingMenuControllerCustomizable) {
+        self.options = options
+
+        guard UIDevice.current.userInterfaceIdiom != .pad || !isPresentedModally else { return }
+
+        switch options.componentType {
+        case .all(let menuOptions, _):
+            self.menuOptions = menuOptions
+        case .menuView(let menuOptions):
+            self.menuOptions = menuOptions
+        default: break
+        }
+
+        setupMenuView()
+        setupMenuController()
+
         move(toPage: currentPage, animated: false)
     }
     
@@ -199,8 +220,14 @@ open class PagingMenuController: UIViewController {
     fileprivate func constructMenuView() {
         guard let menuOptions = self.menuOptions else { return }
         
-        menuView = MenuView(menuOptions: menuOptions)
-        
+        let viewWidth: CGFloat
+        if UIDevice.current.userInterfaceIdiom == .pad, isPresentedModally {
+            viewWidth = view.frame.width
+        } else {
+            viewWidth = UIApplication.shared.keyWindow?.bounds.width ?? UIScreen.main.bounds.width
+        }
+        menuView = MenuView(menuOptions: menuOptions, viewWidth: viewWidth)
+
         addTapGestureHandler()
         addSwipeGestureHandler()
     }
@@ -588,5 +615,24 @@ extension PagingMenuController {
     
     fileprivate func raise(_ reason: String) {
         NSException(name: NSExceptionName(rawValue: exceptionName), reason: reason, userInfo: nil).raise()
+    }
+}
+
+extension UIViewController {
+
+    fileprivate var isPresentedModally: Bool {
+
+        if presentingViewController != nil, navigationController == nil {
+            return true
+        }
+        if let navigationController = navigationController,
+           navigationController.presentingViewController != nil,
+           navigationController.viewControllers.first == self {
+            return true
+        }
+        if let tabBarController = tabBarController, tabBarController.presentingViewController is UITabBarController {
+            return true
+        }
+        return false
     }
 }


### PR DESCRIPTION
**Fix**
- Fix logic get window width from screen width to view controller width

**CHANGE**
- Change life cycle for setup `PagingMenuController`

**Result**
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-03 at 03 29 42](https://github.com/user-attachments/assets/c0396058-82c3-4e84-9c75-27ecd759a410)
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-04-03 at 03 30 03](https://github.com/user-attachments/assets/f880dda3-ed79-4e50-b6ae-7a2d4a994170)

